### PR TITLE
Fix window order slots (Issue #2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
 helloagents/
+
+# Xcode / xcodebuild
+build/

--- a/VSCode-Switcher/ContentView.swift
+++ b/VSCode-Switcher/ContentView.swift
@@ -238,6 +238,10 @@ final class VSCodeWindowsViewModel: ObservableObject {
         windowAliases[id]
     }
 
+    func slotIndex(for window: VSCodeWindowItem) -> Int? {
+        switcher.slotIndexForWindowID(window.id)
+    }
+
     func setAlias(_ alias: String?, forWindowID id: String) {
         switcher.setWindowAlias(alias, forWindowID: id)
         windowAliases = switcher.windowAliases()
@@ -514,10 +518,10 @@ struct ContentView: View {
     }
 
     private func hotKeyLabel(for window: VSCodeWindowItem) -> String {
-        guard let index = viewModel.windows.prefix(10).firstIndex(where: { $0.id == window.id }) else {
+        guard let slotIndex = viewModel.slotIndex(for: window), slotIndex >= 0, slotIndex < 10 else {
             return ""
         }
-        let number = index == 9 ? "0" : String(index + 1)
+        let number = slotIndex == 9 ? "0" : String(slotIndex + 1)
         return "⌃⌥\(number)"
     }
 }


### PR DESCRIPTION
修复窗口列表顺序错乱：windowOrder 作为槽位序列保留空槽，新窗口优先填空槽；快捷键/标签按槽位编号稳定。\n\nFixes #2.